### PR TITLE
Allow to change order in sortBy function by configuration

### DIFF
--- a/lib/ulits/pouchDBQuery.js
+++ b/lib/ulits/pouchDBQuery.js
@@ -48,8 +48,8 @@ function () {
   }, {
     key: "sortBy",
     value: function sortBy(field) {
-      var order = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'ASC';
-      var fieldSortConfig = (0, _defineProperty2.default)({}, field, 'desc');
+      var order = arguments.length > 1 && arguments[1] !== undefined ? arguments[1].toLowerCase() : 'desc';
+      var fieldSortConfig = (0, _defineProperty2.default)({}, field, order);
       this._request.sort = (0, _isEmpty.default)(this._request.sort) ? [fieldSortConfig] : [].concat((0, _toConsumableArray2.default)(this._request.sort), [fieldSortConfig]);
 
       if (!this._request.selector.hasOwnProperty(field)) {


### PR DESCRIPTION
In function 'sortBy' a variable 'order' was set to contain the configured ordering value.
This variable was then never used in this function and in 'fieldSortConfig' the order was hardcoded and for that can't be changed via configuration.

This change should fix this issue :)